### PR TITLE
Fixes #3118 : Upgrade Jgit to 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
-      <version>1.3.0.201202151440-r</version>
+      <version>2.1.0.201209190230-r</version>
     </dependency>
   
     <!-- Test dependencies -->


### PR DESCRIPTION
A dependency upgrade for Jgit 

Here we upgrade to Jgit 2.1 (before was 1.3)

I made another pull request to upgrade to Jgit 2.2 ( last release was from mid-december) https://github.com/Normation/cf-clerk/pull/3

This one should not cause any problem
