### PR TITLE
Fixes #3118 : upgrade Jgit to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
-      <version>1.3.0.201202151440-r</version>
+      <version>2.2.0.201212191850-r</version>
     </dependency>
   
     <!-- Test dependencies -->


### PR DESCRIPTION
linked to issue http://www.rudder-project.org/redmine/issues/3118

this upgrade is needed to resolve http://www.rudder-project.org/redmine/issues/3102

https://github.com/Normation/cf-clerk/pull/2 can also be accepted (upgrade to 2.1) as version 2.2 (out for 2 weeks when making the pull request)

maybe this one could be accepted later after upgrade to 2.1 had been accepted
