### PR TITLE
Ref #3077: use modificationId in eventLog related APIs

### DIFF
--- a/src/main/scala/com/normation/cfclerk/services/TechniqueLibraryUpdateNotification.scala
+++ b/src/main/scala/com/normation/cfclerk/services/TechniqueLibraryUpdateNotification.scala
@@ -36,6 +36,7 @@ package com.normation.cfclerk.services
 
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
 
 /**
  * A trait that allows its implementation to get notification 
@@ -59,6 +60,6 @@ trait TechniquesLibraryUpdateNotification {
    * Description is a log description to explain why techniques should be updated 
    * (user action, commit, etc). 
    */
-  def updatedTechniques(TechniqueIds:Seq[TechniqueId], actor: EventActor, reason: Option[String]) : Unit
+  def updatedTechniques(TechniqueIds:Seq[TechniqueId], modId: ModificationId, actor: EventActor, reason: Option[String]) : Unit
   
 }

--- a/src/main/scala/com/normation/cfclerk/services/UpdateTechniqueLibrary.scala
+++ b/src/main/scala/com/normation/cfclerk/services/UpdateTechniqueLibrary.scala
@@ -37,6 +37,7 @@ package com.normation.cfclerk.services
 import net.liftweb.common.Box
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
 
 /**
  * A trait that allows to update the reference policy
@@ -48,7 +49,7 @@ trait UpdateTechniqueLibrary {
    * Update the lib, and return the list of
    * actually updated policy templates. 
    */
-  def update(actor:EventActor, reason: Option[String]) : Box[Seq[TechniqueId]]
+  def update(modId: ModificationId, actor:EventActor, reason: Option[String]) : Box[Seq[TechniqueId]]
   
   /**
    * Allows callbacks to be called on a Policy Template library update. 


### PR DESCRIPTION
Linked to http://www.rudder-project.org/redmine/issues/3077 and http://www.rudder-project.org/redmine/issues/3002

https://github.com/Normation/cf-clerk/pull/2 or https://github.com/Normation/cf-clerk/pull/3 needs to be accepted too (prerequisite of http://www.rudder-project.org/redmine/issues/3102)
