### PR TITLE
Fixes #3281 : escape automatically text in directive, and add a RAW cons...

### DIFF
--- a/src/main/scala/com/normation/cfclerk/domain/Constraint.scala
+++ b/src/main/scala/com/normation/cfclerk/domain/Constraint.scala
@@ -54,7 +54,7 @@ object Constraint {
   val regexTypes = "mail" :: "ip" :: Nil
   val stringTypes = "string" :: "perm" :: "textarea" :: Nil ::: regexTypes ::: sizeTypes
   val validTypes = "integer" :: "uploadedfile" :: "destinationfullpath" :: "date" :: "datetime" :: "time" ::
-    "boolean" :: Nil ::: stringTypes
+    "boolean" :: "raw" :: Nil ::: stringTypes
 
   def apply(typeName: String = "string", default: Option[String] = None, mayBeEmpty: Boolean = false, regex: RegexConstraint = RegexConstraint()): Constraint = {
 

--- a/src/main/scala/com/normation/cfclerk/domain/VariableAndSectionSpec.scala
+++ b/src/main/scala/com/normation/cfclerk/domain/VariableAndSectionSpec.scala
@@ -195,6 +195,8 @@ sealed trait VariableSpec {
   def constraint: Constraint
 }
 
+// A SystemVariable is automatically filled by Rudder
+// It has the RAW constraint, meaning it is *NOT* escaped
 case class SystemVariableSpec(
   override val name: String,
   val description: String,
@@ -207,7 +209,8 @@ case class SystemVariableSpec(
   // we expect that by default the variable will be checked
   val checked: Boolean = true,
 
-  val constraint: Constraint = Constraint()
+  // A system variable is always of the "raw" type, meaning it won't be escaped
+  val constraint: Constraint = Constraint(typeName = "raw")
 
 ) extends VariableSpec with HashcodeCaching {
 

--- a/src/test/resources/testVariable.xml
+++ b/src/test/resources/testVariable.xml
@@ -84,4 +84,11 @@
 			</CONSTRAINT>
 		</INPUT>
 
+		<INPUT>
+			<NAME>raw_type</NAME>
+			<DESCRIPTION>a variable that isn't automatically escaped</DESCRIPTION>
+			<CONSTRAINT>
+				<TYPE>raw</TYPE>
+			</CONSTRAINT>
+		</INPUT>
 </VARIABLES>

--- a/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
+++ b/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
@@ -54,18 +54,21 @@ import org.joda.time.format._
 import org.junit.runner._
 import org.specs2.mutable._
 import org.specs2.runner._
-import net.liftweb.common.Failure
+import net.liftweb.common._
 
 @RunWith(classOf[JUnitRunner])
 class VariableTest extends Specification {
   def variableSpecParser = new VariableSpecParser()
 
-  val nbVariables = 10
+  val nbVariables = 11
   val refName = "name"
   val refDescription = "description"
   val refValue = "value"
   val dateValue = "2010-01-16T12:00:00.000+01:00"
   val listValue = "value1;value2"
+
+  val rawValue = """This is a test \ " \\ """
+  val escapedTo = """This is a test \\ \" \\\\ """
 
   val refItem = Seq(ValueLabel("value", "label"), ValueLabel("value2", "label2"))
 
@@ -81,6 +84,7 @@ class VariableTest extends Specification {
   val mailVar = "$MAIL"
   val ipVar = "$IP"
   val varList = "varlist"
+  val rawVar = "raw_type"
 
   val variables = {
     val doc =
@@ -130,6 +134,7 @@ class VariableTest extends Specification {
       variables must haveKey(sizeVar)
       variables must haveKey(mailVar)
       variables must haveKey(ipVar)
+      variables must haveKey(rawVar)
     }
   }
 
@@ -255,6 +260,20 @@ class VariableTest extends Specification {
     implicit val listVariable = variables(varList)
     haveType("string")
     notBeMultivalued
+  }
+
+  "Raw variable" should {
+    implicit val rawVariable = variables(rawVar)
+    haveType("raw")
+    rawVariable.saveValue(rawValue)
+    rawVariable.getTypedValues.openOrThrowException("Invalid content for the raw variable") must containTheSameElementsAs(Seq(rawValue))
+  }
+
+  "Simple variable " should {
+    implicit val simpleVariable = variables(simpleName)
+    haveType("string")
+    simpleVariable.saveValue(rawValue)
+    simpleVariable.getTypedValues.openOrThrowException("Invalid content for the escaped variable") must containTheSameElementsAs(Seq(escapedTo))
   }
 
   checkType("size-kb", sizeVar)


### PR DESCRIPTION
...traint for when you don't want to escpe them. System variable are automatically raw

The escaping replace \ by \ and " by \"

In a nutshell:
- systemVariable will behave the same (non escaped automatically)
- all variables by default are escaped
- a contraint "raw" is created, allowing to define variable that we don't want to be escaped automatically
