### PR TITLE
Fixes #4537: use a cache for read promise templates

### DIFF
--- a/src/main/scala/com/normation/cfclerk/domain/Cf3PromisesFileInfo.scala
+++ b/src/main/scala/com/normation/cfclerk/domain/Cf3PromisesFileInfo.scala
@@ -82,10 +82,11 @@ case class PreparedTemplates(
  * It gives what template to copy where.
  */
 case class Cf3PromisesFileTemplateCopyInfo(
-    source     : Cf3PromisesFileTemplateId  // the full name where the template is found
- ,  destination: String
+    source     : String  // content of the template as a string
+  , id         : Cf3PromisesFileTemplateId
+  , destination: String
 ) extends HashcodeCaching {
-  override def toString() = "Tml package id %s, Tml name %s, Tml destination %s".format(source.techniqueId, source.name, destination)
+  override def toString() = s"Promise template ${id.techniqueId}/${id.name}; destination ${destination}"
 }
 
 /**

--- a/src/main/scala/com/normation/cfclerk/services/Cf3PromisesFileWriterService.scala
+++ b/src/main/scala/com/normation/cfclerk/services/Cf3PromisesFileWriterService.scala
@@ -35,6 +35,7 @@
 package com.normation.cfclerk.services
 
 import com.normation.cfclerk.domain._
+import net.liftweb.common.Box
 
 /**
  * Deals with templates : prepare the templates, fetch variables needed by a policy,
@@ -44,6 +45,12 @@ import com.normation.cfclerk.domain._
  */
 trait Cf3PromisesFileWriterService {
 
+
+  /**
+   * For a set of technique, read all the template from the file system in
+   * an efficient way
+   */
+  def readTemplateFromFileSystem(techniques:Set[TechniqueId]) : Box[Map[Cf3PromisesFileTemplateId, Cf3PromisesFileTemplateCopyInfo]]
 
   /**
    * Write the current seq of template file a the path location, replacing the variables found in variableSet

--- a/src/test/scala/com/normation/cfclerk/services/DummyPolicyTranslator.scala
+++ b/src/test/scala/com/normation/cfclerk/services/DummyPolicyTranslator.scala
@@ -35,8 +35,11 @@
 package com.normation.cfclerk.services
 
 import com.normation.cfclerk.domain._
+import net.liftweb.common.Box
 
 class DummyPolicyTranslator extends Cf3PromisesFileWriterService {
+
+  def readTemplateFromFileSystem(techniques:Set[TechniqueId]) : Box[Map[Cf3PromisesFileTemplateId, Cf3PromisesFileTemplateCopyInfo]] = null
 
   def prepareCf3PromisesFileTemplate(policyContainer : Cf3PolicyDraftContainer, extraVariables : Map[String, Variable]) : PreparedTemplates = {
     null


### PR DESCRIPTION
Nothing really fancy: the main idea is to change Cf3PromisesFileTemplateCopyInfo to have the template content as a string in place of a path, and to add a bulk-read method based on technique ids elsewhere. As soon as the read and use part are decoupled, it's easy to read things at only one point (see the use in Rudder). 

Note: a lots of changes are due to indent modification, the actual changes are more clear is compared with ?w=1
