### PR TITLE
Fixes #4786: remove CLIENTSLIST from system spec variables

### DIFF
--- a/src/main/scala/com/normation/cfclerk/services/impl/SystemVariableSpecServiceImpl.scala
+++ b/src/main/scala/com/normation/cfclerk/services/impl/SystemVariableSpecServiceImpl.scala
@@ -48,10 +48,6 @@ class SystemVariableSpecServiceImpl extends SystemVariableSpecService {
       SystemVariableSpec("ALLOWCONNECT"   , "List of ip allowed to connect to the node (policyserver + children if any)"
                                           , multivalued = true
       )
-    , SystemVariableSpec("CLIENTSLIST"    , "List of agent to contact via runagent"
-                                          , multivalued = true
-                                          , constraint = Constraint(mayBeEmpty=true)
-      )
     , SystemVariableSpec("CLIENTSFOLDERS" , "List of agent to contact via runagent"
                                           , multivalued = true
                                           , constraint = Constraint(mayBeEmpty=true)

--- a/src/main/scala/com/normation/cfclerk/xmlparsers/TechniqueParser.scala
+++ b/src/main/scala/com/normation/cfclerk/xmlparsers/TechniqueParser.scala
@@ -142,7 +142,14 @@ class TechniqueParser(
    *
    */
   private[this] def parseSysvarSpecs(node: Node, id:TechniqueId) : Set[SystemVariableSpec] = {
-    (node \ SYSTEMVARS_ROOT \ SYSTEMVAR_NAME).map(x => systemVariableSpecService.get(x.text)).toSet
+    (node \ SYSTEMVARS_ROOT \ SYSTEMVAR_NAME).map{ x =>
+      try {
+        systemVariableSpecService.get(x.text)
+      } catch {
+        case ex:NoSuchElementException =>
+          throw new ParsingException(s"The system variable ${x.text} is not defined: perhaps the metadata.xml for technique '${id.toString}' is not up to date")
+      }
+    }.toSet
   }
 
 }


### PR DESCRIPTION
The try/catch is necessary to allow Rudder to boot and let the user have a chance to update its technique library. 

There is something really broken in Rudder if a problem in the technique library make it non bootable...
