### PR TITLE
Fixes #5254: update cfclerk version to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
   <parent>
     <groupId>com.normation</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>2.11.0~beta2-SNAPSHOT</version>
+    <version>2.12.0~alpha1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cfclerk</artifactId>
@@ -135,12 +135,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.8</version>
+      <version>${commons-codec-version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
-      <version>2.3.1.201302201838-r</version>
+      <version>${jgit-version}</version>
     </dependency>
   
     <!-- Test dependencies -->

--- a/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -461,7 +461,8 @@ class GitTechniqueReader(
 
 
       var root = maybeCategories.get(RootTechniqueCategoryId) match {
-          case None => sys.error("Missing techniques root category in Git, expecting category descriptor for Git path: '%s'".format(
+          case None =>
+            sys.error("Missing techniques root category in Git, expecting category descriptor for Git path: '%s'".format(
               repo.db.getWorkTree.getPath + canonizedRelativePath.map( "/" + _ + "/" + categoryDescriptorName).getOrElse("")))
           case Some(sub:SubTechniqueCategory) =>
             logger.error("Bad type for root category in the Technique Library. Please check the hierarchy of categories")

--- a/src/test/resources/techniquesRoot/cat2/bad_category.xml
+++ b/src/test/resources/techniquesRoot/cat2/bad_category.xml
@@ -1,0 +1,5 @@
+<xml>
+    <name>Bad_cat2</name>
+    <descripton>This is a bad name, but that ends like a good one.
+    </descripton>
+</xml>

--- a/src/test/scala/com/normation/cfclerk/services/JGitPackageReaderTest.scala
+++ b/src/test/scala/com/normation/cfclerk/services/JGitPackageReaderTest.scala
@@ -122,7 +122,7 @@ trait JGitPackageReaderSpec extends Specification with Loggable {
     "has one policy package..." in 1 === rootCat.packageIds.size
     "...with name p_root_1" in "p_root_1" === rootCat.packageIds.head.name.value
     "...with version 1.0" in "1.0" === rootCat.packageIds.head.version.toString
-    "has 1 valid subcategory (because cat has no category.xml descriptor)" in 1 === rootCat.subCategoryIds.size
+    "has 1 valid subcategory (because cat2 has no category.xml descriptor)" in 1 === rootCat.subCategoryIds.size
     "...with name cat1" in rootCat.subCategoryIds.head === rootCat.id / "cat1"
   }
 


### PR DESCRIPTION
There seems to have a change in the semantic of "path" in JGIT treewalks that no longer include a leading "/".

So, in place of "/category.xml" for the root category, we have to look for "category.xml" - nothing change for sub-categories, as we are comparing for the suffixe "/category.xml" in "..../category.xml". 

So, I added a special case for files under root in the FileTreeFilter, and also added a test for a descriptor trying to cheat with a name ending with "category.xml". 
